### PR TITLE
Add web log streaming

### DIFF
--- a/src/herbarium_processor/web/main.py
+++ b/src/herbarium_processor/web/main.py
@@ -4,6 +4,10 @@ from fastapi.staticfiles import StaticFiles
 from uuid import uuid4
 from pathlib import Path
 from typing import List
+import threading
+import io
+import sys
+from contextlib import redirect_stdout
 
 from herbarium_processor.config import ROOT_DIR, TMP_DIR
 from herbarium_processor.core.ocr.ocr_client import OcrClient
@@ -20,6 +24,69 @@ app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 MAX_FILES = 10
 
+job_logs: dict[str, list[str]] = {}
+job_status: dict[str, str] = {}
+
+
+class LogCapture(io.StringIO):
+    def __init__(self, job_id: str, orig_stdout):
+        super().__init__()
+        self.job_id = job_id
+        self.orig = orig_stdout
+
+    def write(self, s: str):
+        self.orig.write(s)
+        job_logs.setdefault(self.job_id, []).append(s)
+
+    def flush(self):
+        self.orig.flush()
+
+
+def process_job(job_id: str, files_data: list[tuple[str, bytes]]):
+    job_status[job_id] = "processing"
+    job_dir = TMP_DIR / f"job_{job_id}"
+    images_dir = job_dir / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+
+    with redirect_stdout(LogCapture(job_id, sys.stdout)):
+        ocr = OcrClient()
+        targets: List[SpecimenLabel] = []
+        for fname, data in files_data:
+            dest = images_dir / fname
+            dest.write_bytes(data)
+            rel_path = dest.relative_to(ROOT_DIR)
+            ocr.extract_text_json(str(rel_path))
+            ocr_json = TMP_DIR / f"ocr_ai_input_{dest.stem}.json"
+            targets.append(
+                SpecimenLabel(
+                    id=dest.stem,
+                    img_path=str(rel_path),
+                    ocr_path=str(ocr_json.relative_to(ROOT_DIR)),
+                )
+            )
+
+        builder = PromptBuilder(
+            csv_path="data/csv/fake_canonical.csv",
+            field_list=FIELD_LIST,
+            shot_data=[],
+            template_path="prompts/templates/herbarium_prompt.j2",
+        )
+
+        csv_rel = (job_dir / "results.csv").relative_to(ROOT_DIR)
+        runner = LabelExtractionBatchRunner(
+            output_csv_path=str(csv_rel),
+            output_dir=str(job_dir.relative_to(ROOT_DIR)),
+            prompt_builder=builder,
+            targets=targets,
+        )
+
+        try:
+            runner.run()
+            job_status[job_id] = "complete"
+        except Exception as e:
+            job_logs.setdefault(job_id, []).append(f"Error: {e}\n")
+            job_status[job_id] = "error"
+
 
 @app.get("/", response_class=HTMLResponse)
 async def index():
@@ -31,39 +98,12 @@ async def upload(files: List[UploadFile] = File(...)):
         raise HTTPException(status_code=400, detail=f"Upload between 1 and {MAX_FILES} images")
 
     job_id = str(uuid4())
-    job_dir = TMP_DIR / f"job_{job_id}"
-    images_dir = job_dir / "images"
-    images_dir.mkdir(parents=True, exist_ok=True)
-
-    ocr = OcrClient()
-    targets: List[SpecimenLabel] = []
+    file_data = []
     for f in files:
-        dest = images_dir / f.filename
-        dest.write_bytes(await f.read())
-        rel_path = dest.relative_to(ROOT_DIR)
-        ocr.extract_text_json(str(rel_path))
-        ocr_json = TMP_DIR / f"ocr_ai_input_{dest.stem}.json"
-        targets.append(
-            SpecimenLabel(id=dest.stem, img_path=str(rel_path), ocr_path=str(ocr_json.relative_to(ROOT_DIR)))
-        )
+        file_data.append((f.filename, await f.read()))
 
-    builder = PromptBuilder(
-        csv_path="data/csv/fake_canonical.csv",
-        field_list=FIELD_LIST,
-        shot_data=[],
-        template_path="prompts/templates/herbarium_prompt.j2",
-    )
-
-    csv_rel = (job_dir / "results.csv").relative_to(ROOT_DIR)
-    runner = LabelExtractionBatchRunner(
-        output_csv_path=str(csv_rel),
-        output_dir=str(job_dir.relative_to(ROOT_DIR)),
-        prompt_builder=builder,
-        targets=targets,
-    )
-
-    # TODO: Offload this work to a background task queue like Celery
-    runner.run()
+    thread = threading.Thread(target=process_job, args=(job_id, file_data))
+    thread.start()
 
     return {"job_id": job_id}
 
@@ -73,4 +113,12 @@ async def download(job_id: str):
     if not csv_path.exists():
         raise HTTPException(status_code=404, detail="Results not found")
     return FileResponse(csv_path, media_type="text/csv", filename="results.csv")
+
+
+@app.get("/logs/{job_id}")
+async def logs(job_id: str):
+    return {
+        "logs": "".join(job_logs.get(job_id, [])),
+        "status": job_status.get(job_id, "unknown"),
+    }
 

--- a/src/herbarium_processor/web/static/index.html
+++ b/src/herbarium_processor/web/static/index.html
@@ -11,6 +11,8 @@
     <button type="submit">Upload</button>
 </form>
 <div id="status"></div>
+<pre id="logs" style="background:#f0f0f0;padding:1em;
+    white-space:pre-wrap;border:1px solid #ccc;max-height:300px;overflow:auto"></pre>
 <script>
 document.getElementById('upload-form').addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -24,19 +26,37 @@ document.getElementById('upload-form').addEventListener('submit', async (e) => {
         formData.append('files', file);
     }
     const status = document.getElementById('status');
+    const logEl = document.getElementById('logs');
     status.textContent = 'Processing...';
+    logEl.textContent = '';
     const resp = await fetch('/upload', { method: 'POST', body: formData });
     if (!resp.ok) {
         status.textContent = 'Upload failed';
         return;
     }
     const data = await resp.json();
-    const link = document.createElement('a');
-    link.href = `/download/${data.job_id}`;
-    link.textContent = 'Download CSV';
-    link.download = 'results.csv';
-    status.innerHTML = '';
-    status.appendChild(link);
+
+    async function fetchLogs() {
+        const r = await fetch(`/logs/${data.job_id}`);
+        if (!r.ok) return;
+        const j = await r.json();
+        logEl.textContent = j.logs;
+        if (j.status === 'complete') {
+            clearInterval(timer);
+            const link = document.createElement('a');
+            link.href = `/download/${data.job_id}`;
+            link.textContent = 'Download CSV';
+            link.download = 'results.csv';
+            status.innerHTML = '';
+            status.appendChild(link);
+        } else if (j.status === 'error') {
+            clearInterval(timer);
+            status.textContent = 'Job failed';
+        }
+    }
+
+    const timer = setInterval(fetchLogs, 1000);
+    fetchLogs();
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- run batch jobs in background threads
- capture stdout logs and expose `/logs/{job_id}`
- poll log endpoint from the web UI and show progress

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ca4beb8883299e84ded5b87a239b