### PR TITLE
Add direct edit endpoint

### DIFF
--- a/src/herbarium_processor/web/main.py
+++ b/src/herbarium_processor/web/main.py
@@ -45,6 +45,11 @@ async def index():
     return (STATIC_DIR / "index.html").read_text()
 
 
+@app.get("/edit/{job_id}", response_class=HTMLResponse)
+async def edit(job_id: str):
+    return (STATIC_DIR / "index.html").read_text()
+
+
 @app.post("/upload")
 async def upload(files: List[UploadFile] = File(...)):
     if not files or len(files) > MAX_FILES:

--- a/src/herbarium_processor/web/static/index.html
+++ b/src/herbarium_processor/web/static/index.html
@@ -73,11 +73,15 @@
 
     <script>
         const { createApp } = Vue;
+
+        const pathParts = window.location.pathname.split('/');
+        const presetJobId = pathParts.length >= 3 && pathParts[1] === 'edit' ? pathParts[2] : '';
+
         createApp({
             data() {
                 return {
-                    stage: 'upload',
-                    jobId: '',
+                    stage: presetJobId ? 'edit' : 'upload',
+                    jobId: presetJobId,
                     rows: [],
                     fieldnames: [],
                     status: '',
@@ -90,6 +94,11 @@
                     startWidth: 0,
                     cropper: null
                 };
+            },
+            created() {
+                if (this.jobId) {
+                    this.fetchResults();
+                }
             },
             methods: {
                 async upload() {


### PR DESCRIPTION
## Summary
- add `/edit/{job_id}` endpoint to jump straight to editing HTML
- detect preset job id in the UI based on path and fetch results automatically

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f3fff10083299903a9c608a1c855